### PR TITLE
Fix OTel span timing to cover full streaming lifecycle

### DIFF
--- a/chat_complete.go
+++ b/chat_complete.go
@@ -56,7 +56,6 @@ func (c *ChatCompleter) ChatComplete(ctx context.Context, req gai.ChatCompleteRe
 			attribute.Int("ai.message_count", len(req.Messages)),
 		),
 	)
-	defer span.End()
 
 	if len(req.Messages) == 0 {
 		panic("no messages")
@@ -188,6 +187,8 @@ func (c *ChatCompleter) ChatComplete(ctx context.Context, req gai.ChatCompleteRe
 	meta := &gai.ChatCompleteResponseMetadata{}
 
 	res := gai.NewChatCompleteResponse(func(yield func(gai.MessagePart, error) bool) {
+		defer span.End()
+
 		for chunk, err := range chat.SendStream(ctx, lastContent.Parts...) {
 			if err != nil {
 				span.RecordError(err)


### PR DESCRIPTION
Move `span.End()` from main function to streaming closure to ensure the span remains active during the entire chat completion operation, including streaming response generation and final token usage capture.